### PR TITLE
fix(tabs): react to changes within fw-tabs

### DIFF
--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -14,6 +14,7 @@ export class Tabs {
 
   @Element()
   el!: HTMLElement;
+  private mutationO?: MutationObserver;
 
   /**
    * Child Elements/Tab Items
@@ -31,6 +32,11 @@ export class Tabs {
   @State()
   activeChildClass = '';
 
+  init() {
+    this.tabs = Array.from(this.el.querySelectorAll('fw-tab'));
+    this.displayTab(0);
+  }
+
   displayTab(index: number) {
     this.activeTabIndex = index;
     this.tabs = this.tabs?.map((tab, i) => {
@@ -40,8 +46,21 @@ export class Tabs {
   }
 
   componentWillLoad() {
-    this.tabs = Array.from(this.el.querySelectorAll('fw-tab'));
-    this.displayTab(0);
+    this.init();
+  }
+
+  connectedCallback() {
+    this.mutationO = new MutationObserver(() => {
+      this.init();
+    });
+    this.mutationO.observe(this.el, { childList: true });
+  }
+
+  disconnectedCallback() {
+    if (this.mutationO) {
+      this.mutationO.disconnect();
+      this.mutationO = undefined;
+    }
   }
 
   render() {


### PR DESCRIPTION
This adds a mutation Observer to tabs component so that if there is a change in fw-tab, the entire
component re-renders


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
